### PR TITLE
more ptxdist patches

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,7 +5,7 @@ INSTALL_DATA = @INSTALL_DATA@ -D
 prefix = @prefix@
 exec_prefix = @exec_prefix@
 
-SHAREDOPT = -shared -shared -fPIC,-Wl,-soname,libcgi.so.0
+SHAREDOPT = -shared -shared -fPIC -Wl,-soname,libcgi.so.0
 libdir = $(prefix)/lib
 incdir = $(prefix)/include/libcgi
 mandir	= $(prefix)/man/man3

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,4 +1,5 @@
 INSTALL = @INSTALL@ -D
+LN_S = @LN_S@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@ -D
 INSTALL_DATA = @INSTALL_DATA@ -D
 
@@ -53,11 +54,12 @@ src/libcgi.a: $(OBJS)
 	$(AR) rc src/libcgi.a $(OBJS)
 
 src/libcgi.so: $(SHOBJS)
-	$(CC) $(SHAREDOPT) -o src/libcgi.so $(SHOBJS) $(EXTRA_LIBS)
+	$(CC) $(SHAREDOPT) -o src/libcgi.so.0 $(SHOBJS) $(EXTRA_LIBS)
 
 install:
 	$(INSTALL) -m 0644 src/libcgi.a $(DESTDIR)/$(libdir)/libcgi.a
-	$(INSTALL) -m 0644 src/libcgi.so $(DESTDIR)/$(libdir)/libcgi.so
+	$(INSTALL) -m 0644 src/libcgi.so.0 $(DESTDIR)/$(libdir)/libcgi.so.0
+	$(LN_S) libcgi.so.0 $(DESTDIR)/$(libdir)/libcgi.so
 	$(INSTALL) -m 0644 src/cgi.h $(DESTDIR)/$(incdir)/cgi.h
 	$(INSTALL) -m 0644 src/session.h $(DESTDIR)/$(incdir)/session.h
 

--- a/configure.in
+++ b/configure.in
@@ -4,6 +4,7 @@ AC_CONFIG_HEADER(src/config.h)
 dnl Searching for a compiler
 AC_PROG_CC
 AC_PROG_INSTALL
+AC_PROG_LN_S
 
 AC_DEFINE(HAVE_MD5)
 


### PR DESCRIPTION
Two things here. First is the patch from Michael Olbrich which appeared as is in the ptxdist project. I use this with ptxdist for months now, it works. The other one is a typo Michael Olbrich fixed in Robert Schwebel's patch which was part of my patch set in da3b71831811749a41c9a08d7d42e77e537a0bdf. Because I reapplied the ptxdist patches to fdf99b50314edd0b15077b31b86846c8d4a235b3 and made a rebase to master, this one appears as changeset from Robert fixing this typo. 

I confirmed compiling and linking on Debian Wheezy.