### PR TITLE
cgi_include():

### DIFF
--- a/src/cgi.h
+++ b/src/cgi.h
@@ -53,7 +53,7 @@ extern char *cgi_unescape_special_chars(const char *str);
 extern char *cgi_escape_special_chars(const unsigned char *str);
 extern char *cgi_param_multiple(const char *name);
 extern char *htmlentities(const char *str);
-extern int cgi_include(const char *filename);
+extern int cgi_include(const char *path);
 extern formvars *cgi_process_form(void);
 extern int cgi_init(void);
 extern void cgi_end(void);


### PR DESCRIPTION
Removed call to cgi_init_headers() as libcgi_error() makes the call itself.

Made more efficient by not using formatted in/output functions.

Improved robustness by acknowledging entire file is read/written.

As included files are generally expected to be less than huge text files,
efficiency is improved by reading/writing the file in its entirety rather than
line-by-line.

	modified:   cgi.c
	modified:   cgi.h - changed parameter name to 'path'