### PR TITLE
process_data()

### DIFF
--- a/src/cgi.c
+++ b/src/cgi.c
@@ -97,11 +97,9 @@ formvars *process_data(const char *query, formvars **start, formvars **last,
 	while (*query)
 	{
 		/* allocate and initialise memory for new formvars */
-		item = (formvars *)malloc(sizeof(formvars));
+		item = (formvars *)calloc(1, sizeof(formvars));
 		if (!item)
 			libcgi_error(E_MEMORY, "%s, line %s", __FILE__, __LINE__);
-
-		memset(item, 0, sizeof(formvars));
 
 		/* find end of name and value pair (with or without value) */
 		for (amp = query; *amp != sep_name && *amp; ++amp);

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -112,7 +112,7 @@ formvars *process_data(const char *query, formvars **start, formvars **last,
 		     ++equal);
 
 		name_len = equal - query;
-		value_len = amp - (equal + 1);
+		value_len = (*equal == sep_value) ? amp - (equal + 1) : 0;
 
 		/* add name and value to new formvar item */
 		item->name = strndup(query, name_len);

--- a/src/session.c
+++ b/src/session.c
@@ -107,7 +107,8 @@ const char *session_error_message[] = {
 // cgi.c
 extern int headers_initialized;
 extern void libcgi_error(int error_code, const char *msg, ...);
-extern formvars *process_data(char *query, formvars **start, formvars **last, const char delim, const char sep);
+extern formvars *process_data(char *query, formvars **start, formvars **last,
+                              const char sep_value, const char sep_name);
 
 // Error types
 typedef enum SESS_ERROR {

--- a/src/session.c
+++ b/src/session.c
@@ -107,7 +107,7 @@ const char *session_error_message[] = {
 // cgi.c
 extern int headers_initialized;
 extern void libcgi_error(int error_code, const char *msg, ...);
-extern formvars *process_data(char *query, formvars **start, formvars **last,
+extern formvars *process_data(const char *query, formvars **start, formvars **last,
                               const char sep_value, const char sep_name);
 
 // Error types


### PR DESCRIPTION
- Removed unnecessary code that tests for escaped characters.
- Simplified dynamic string allocation by using strndup.
- Improved name and value extraction by catering for missing values.
- Generally refactored resulting in better readability.
- Substituted use of malloc for calloc so as not to have to use memset().
- Memory allocation now only occurs if a 'name' is found. This is more robust as it handles "dodgy" urls / data.