### PR TITLE
Fix minor issues (parameter types) in #8

### DIFF
--- a/src/cgi.c
+++ b/src/cgi.c
@@ -423,8 +423,8 @@ char *cgi_unescape_special_chars(const char *str)
 			 */
 			if (str[1])
 			{
-				hex[0] = hextable[str[1]];
-				hex[1] = hextable[str[2]];
+				hex[0] = hextable[(unsigned char)str[1]];
+				hex[1] = hextable[(unsigned char)str[2]];
 
 				/* valid hex characters? */
 				if (hex[0] != 0xFF && hex[1] != 0xFF)
@@ -447,17 +447,16 @@ char *cgi_unescape_special_chars(const char *str)
 * @return The new string
 * @see cgi_unescape_special_chars
 **/
-char *cgi_escape_special_chars(const unsigned char *str)
+char *cgi_escape_special_chars(const char *str)
 {
-	static const unsigned char hex[] = "0123456789ABCDEF";
-	int i, len;
-	unsigned char *new;
-
-	len = strlen(str);
+	static const char hex[] = "0123456789ABCDEF";
+	char *new;
+	int i;
+	size_t len = strlen(str);
 
 	// worst case scenario: every character would need to be escaped, requiring
 	// 3 times more memory than the original string.
-	new = (unsigned char*)malloc((len * 3) + 1);
+	new = (char*)malloc((len * 3) + 1);
 	if (! new)
 		libcgi_error(E_MEMORY, "%s, line %s", __FILE__, __LINE__);
 
@@ -468,13 +467,12 @@ char *cgi_escape_special_chars(const unsigned char *str)
 		else if (! isalnum(*str) && ! strchr("_-.", *str))
 		{
 			new[i++] = '%';
-			new[i++] = hex[*str >> 4];
-			new[i]   = hex[*str & 0x0F];
+			new[i++] = hex[(unsigned char)*str >> 4];
+			new[i]   = hex[(unsigned char)*str & 0x0F];
 		}
 		else
 			new[i] = *str;
 	}
-
 	new[i] = '\0';
 
 	// free unused memory. no reason to fail.

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -403,14 +403,14 @@ void cgi_end()
 char *cgi_unescape_special_chars(const char *str)
 {
 	char *new, *write;
-	char c = *str;
+	char c;
 	char hex[2];
 
 	new = (char *)malloc(strlen(str) + 1);
 	if (! new)
 		libcgi_error(E_MEMORY, "%s, line %s", __FILE__, __LINE__);
 
-	for (write = new; c; ++str, ++write)
+	for (write = new; *str; ++str, ++write)
 	{
 		c = *str;
 
@@ -437,6 +437,10 @@ char *cgi_unescape_special_chars(const char *str)
 
 		*write = c;
 	}
+	*write = '\0';
+
+	// free unused memory. no reason to fail.
+	new = realloc(new, strlen(new) + 1);
 
 	return new;
 }

--- a/src/cgi.h
+++ b/src/cgi.h
@@ -50,7 +50,7 @@ extern void cgi_init_headers(void);
 extern void cgi_redirect(char *url);
 extern void cgi_fatal(const char *error);
 extern char *cgi_unescape_special_chars(const char *str);
-extern char *cgi_escape_special_chars(const unsigned char *str);
+extern char *cgi_escape_special_chars(const char *str);
 extern char *cgi_param_multiple(const char *name);
 extern char *htmlentities(const char *str);
 extern int cgi_include(const char *filename);


### PR DESCRIPTION
This patch is to fix the minor issues pointed out by @LeSpocky in [#8](https://github.com/rafaelsteil/libcgi/pull/8).

Original parameter types have been restored and explicit casting is now used inside the function instead.