### PR TITLE
Improvements to ltrim() and rtrim().

### DIFF
--- a/src/cgi.h
+++ b/src/cgi.h
@@ -82,8 +82,9 @@ extern char *str_base64_encode(char *str);
 extern char *str_base64_decode(char *str);
 extern char *recvline(FILE *fp);
 extern char *md5(const char *str);
-extern void ltrim(char *str);
-extern void rtrim(char *str);
+extern char *cgi_ltrim(char *str);
+extern char *cgi_rtrim(char *str);
+extern char *cgi_trim(char *str);
 
 extern void slist_add(formvars *item, formvars **start, formvars **last);
 extern int slist_delete(char *name, formvars **start, formvars **last);

--- a/src/cgi.h
+++ b/src/cgi.h
@@ -82,6 +82,8 @@ extern char *str_base64_encode(char *str);
 extern char *str_base64_decode(char *str);
 extern char *recvline(FILE *fp);
 extern char *md5(const char *str);
+extern void ltrim(char *str);
+extern void rtrim(char *str);
 
 extern void slist_add(formvars *item, formvars **start, formvars **last);
 extern int slist_delete(char *name, formvars **start, formvars **last);

--- a/src/string.c
+++ b/src/string.c
@@ -176,12 +176,18 @@ char *stripslashes(char *str)
 */
 void ltrim(char *str)
 {
-	char *s = str;
+    char *s = str;
 
-	while (isspace(*s))
-		s++;
+    /* nothing to do if str is NULL or zero-length */
+	if (! str || ! *str)
+		return;
 
-	while ((*str++ = *s++));
+    while (isspace(*s))
+        s++;
+
+    /* action only needs to be taken if space characters were found */
+    if (s > str)
+        while ((*str++ = *s++));
 }
 
 /**
@@ -201,12 +207,25 @@ void ltrim(char *str)
 void rtrim(char *str)
 {
 	char *s = str;
-	register int i;
 
-	for (i = strlen(s)-1; isspace(*(s+i)); i--)
-		*(s+i) = '\0';
+	/* nothing to do if str is NULL or zero-length */
+	if (! str || ! *str)
+		return;
 
-	while ((*str++ = *s++));
+	/* address of last character in @str */
+	s += strlen(str) - 1;
+
+	/* loop backwards through @str to find last non-space character */
+	while (! (s < str))
+	{
+		if (! isspace(*s))
+			break;
+		--s;
+	}
+	/* terminate @str after the last non-space character, or first character
+	 * if only spaces were found
+	 */
+	s[1] = 0;
 }
 
 /**

--- a/src/string.c
+++ b/src/string.c
@@ -174,20 +174,25 @@ char *stripslashes(char *str)
 * printf("_%s_\n", s);
 * \endcode
 */
-void ltrim(char *str)
+char * cgi_ltrim(char *str)
 {
     char *s = str;
 
     /* nothing to do if str is NULL or zero-length */
-	if (! str || ! *str)
-		return;
+	if (str && *str)
+	{
+		/* find first non-space character */
+		while (isspace(*s))
+			s++;
 
-    while (isspace(*s))
-        s++;
+		/* if any space characters were found, remove them by copying from
+		 * beyond them to the source string
+		 */
+		if (s > str)
+			strcpy(str, s);
+	}
 
-    /* action only needs to be taken if space characters were found */
-    if (s > str)
-        while ((*str++ = *s++));
+	return str;
 }
 
 /**
@@ -204,28 +209,28 @@ void ltrim(char *str)
 * printf("_%s_\n", s);
 * \endcode
 */
-void rtrim(char *str)
+char * cgi_rtrim(char *str)
 {
-	char *s = str;
+	char *last;
 
 	/* nothing to do if str is NULL or zero-length */
-	if (! str || ! *str)
-		return;
-
-	/* address of last character in @str */
-	s += strlen(str) - 1;
-
-	/* loop backwards through @str to find last non-space character */
-	while (! (s < str))
+	if (str && *str)
 	{
-		if (! isspace(*s))
-			break;
-		--s;
+		last = strchr(str, 0) - 1;
+
+		/* loop backwards through @str to find last non-space character */
+		for (; last >= str; --last)
+		{
+			if (! isspace(*last))
+				break;
+		}
+		/* terminate @str after the last non-space character, or first
+		 * character if only spaces were found
+		 */
+		last[1] = 0;
 	}
-	/* terminate @str after the last non-space character, or first character
-	 * if only spaces were found
-	 */
-	s[1] = 0;
+
+	return str;
 }
 
 /**
@@ -242,10 +247,9 @@ void rtrim(char *str)
 * printf("_%s_\n", s);
 * \endcode
 */
-void trim(char *str)
+char * cgi_trim(char *str)
 {
-	ltrim(str);
-	rtrim(str);
+	return cgi_ltrim(cgi_rtrim(str));
 }
 
 /**

--- a/src/string.c
+++ b/src/string.c
@@ -186,10 +186,10 @@ char * cgi_ltrim(char *str)
 			s++;
 
 		/* if any space characters were found, remove them by copying from
-		 * beyond them to the source string
+		 * beyond them to the beginning of the source string
 		 */
 		if (s > str)
-			strcpy(str, s);
+			while ((*str++ = *s++));
 	}
 
 	return str;


### PR DESCRIPTION
- Removed unnecessary processing of NULL pointers and zero-length strings.
- Updates are only made to strings where needed, so memory isn't modified
  needlessly.
- Added declarations to 'cgi.h'.

The two modifications had a huge impact when I ran speed tests. Mostly due to
not attempting to update a string when no space characters are found.

```
modified:   cgi.h
modified:   string.c
```
