### PR TITLE
process_data: use stdlib function instead of glibc function

### DIFF
--- a/src/cgi.c
+++ b/src/cgi.c
@@ -91,7 +91,7 @@ formvars *process_data(const char *query, formvars **start, formvars **last,
 	size_t name_len;
 	size_t value_len;
 	char *str_unesc;
-	const char *query_end = rawmemchr(query, '\0');
+	const char *query_end = strchr(query, '\0');
 
 	if (query == NULL)
 		return *start;


### PR DESCRIPTION
As proposed in discussion to PR #12 the GNU function rawmemchr() was replaced with strchr() from the C std library. With rawmemchr() I had weird segfaults when building with CMake (personal branch) and not paying attention to `feature_test_macros(7)` and `_GNU_SOURCE`.