### PR TITLE
Dfrostbyte tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,25 @@ add_test(slist_process_data
 	cgi-test-slist processdata
 )
 
+# trim
+add_executable(cgi-test-trim
+	cgi_test.c
+	test_trim.c
+	trim.c
+)
+target_link_libraries(cgi-test-trim
+	"${PROJECT_NAME}-shared"
+)
+add_test(test_ltrim
+	cgi-test-trim ltrim
+)
+add_test(test_rtrim
+	cgi-test-trim rtrim
+)
+add_test(test_trim
+	cgi-test-trim trim
+)
+
 # additional tests with valgrind
 find_program(VALGRIND NAMES valgrind)
 if(NOT VALGRIND-NOTFOUND)
@@ -120,5 +139,18 @@ if(NOT VALGRIND-NOTFOUND)
 	add_test(NAME valgrind_slist_process_data
 		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
 					$<TARGET_FILE:cgi-test-slist> processdata
+	)
+
+	add_test(NAME valgrind_test_ltrim
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-trim> ltrim
+	)
+	add_test(NAME valgrind_test_rtrim
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-trim> rtrim
+	)
+	add_test(NAME valgrind_test_trim
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-trim> trim
 	)
 endif(NOT VALGRIND-NOTFOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 Alexander Dahl <post@lespocky.de>
+# Copyright 2016,2017 Alexander Dahl <post@lespocky.de>
 #
 
 include_directories(
@@ -34,3 +34,38 @@ add_test(slist_get_item
 add_test(slist_process_data
 	cgi-test-slist processdata
 )
+
+# additional tests with valgrind
+find_program(VALGRIND NAMES valgrind)
+if(NOT VALGRIND-NOTFOUND)
+	message(STATUS "VALGRIND: ${VALGRIND}")
+
+	add_test(NAME valgrind_slist_add
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-slist> add
+	)
+	add_test(NAME valgrind_slist_delete_zero
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-slist> deletezero
+	)
+	add_test(NAME valgrind_slist_delete_one
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-slist> deleteone
+	)
+	add_test(NAME valgrind_slist_delete_two
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-slist> deletetwo
+	)
+	add_test(NAME valgrind_slist_delete_three
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-slist> deletethree
+	)
+	add_test(NAME valgrind_slist_get_item
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-slist> get
+	)
+	add_test(NAME valgrind_slist_process_data
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test-slist> processdata
+	)
+endif(NOT VALGRIND-NOTFOUND)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,34 @@ include_directories(
 	"${PROJECT_SOURCE_DIR}/src"
 )
 
+# misc
+add_executable(cgi-test
+	cgi_test.c
+	test.c
+)
+target_link_libraries(cgi-test
+	"${PROJECT_NAME}-shared"
+)
+add_test(escape_special_chars
+	cgi-test escape_special_chars
+)
+add_test(process_data
+	cgi-test process_data
+)
+add_test(param_multiple
+	cgi-test param_multiple
+)
+add_test(process_form
+	cgi-test process_form
+)
+add_test(ltrim
+	cgi-test ltrim
+)
+add_test(rtrim
+	cgi-test rtrim
+)
+
+# slist
 add_executable(cgi-test-slist
 	cgi_test.c
 	test_slist.c
@@ -39,6 +67,31 @@ add_test(slist_process_data
 find_program(VALGRIND NAMES valgrind)
 if(NOT VALGRIND-NOTFOUND)
 	message(STATUS "VALGRIND: ${VALGRIND}")
+
+	add_test(NAME valgrind_escape_special_chars
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test> escape_special_chars
+	)
+	add_test(NAME valgrind_process_data
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test> process_data
+	)
+	add_test(NAME valgrind_param_multiple
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test> param_multiple
+	)
+	add_test(NAME valgrind_process_form
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test> process_form
+	)
+	add_test(NAME valgrind_ltrim
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test> ltrim
+	)
+	add_test(NAME valgrind_rtrim
+		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1
+					$<TARGET_FILE:cgi-test> rtrim
+	)
 
 	add_test(NAME valgrind_slist_add
 		COMMAND ${VALGRIND} --leak-check=full --error-exitcode=1

--- a/test/test.c
+++ b/test/test.c
@@ -1,0 +1,100 @@
+/* test cases for module "cgi.c" */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "cgi.h"
+
+static void
+test_cgi_escape_special_chars(void)
+{
+	const char *esc_valid = "%._-+0123456789"
+	                        "abcdefghijklmnopqrstuvwxyz"
+	                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	char str[256];
+	char *esc, *unesc;
+	int c;
+
+	for (c = 0; c < 256; ++c)
+		str[c] = (char) c + 1;
+	str[c] = 0;
+
+	assert(strlen(str) == 255);
+
+	assert(esc = cgi_escape_special_chars(str));
+	assert(unesc = cgi_unescape_special_chars(esc));
+	assert(strcmp(esc, unesc));
+	assert(! strcmp(str, unesc));
+	assert(strspn(esc, esc_valid) == strlen(esc));
+}
+
+static void
+test_process_data(void)
+{
+	formvars *fvp, *iter;
+	const char *data[] = {"1=one&second=%20.two-%30&33=three+three",
+	                      "&1=one&second=%20.two-%30&33=three+three",
+	                      "=noname&1=one&&second=%20.two-%30&33=three+three",
+	                      "==&&=&&1=one&second=%20.two-%30&==&33=three+three&=&",
+	                      NULL};
+	int i;
+
+	for (i = 0; data[i]; ++i)
+	{
+		assert(formvars_start == NULL);
+		assert(formvars_last == NULL);
+
+		fvp = process_data(data[i], &formvars_start, &formvars_last, '=', '&');
+
+		assert(formvars_start && formvars_last && fvp);
+		assert(fvp == formvars_start);
+
+		assert(! strcmp(fvp->name, "1"));
+		assert(! strcmp(fvp->value, "one"));
+		assert(iter = fvp->next);
+
+		assert(! strcmp(iter->name, "second"));
+		assert(! strcmp(iter->value, " .two-0"));
+		assert(iter = iter->next);
+
+		assert(! strcmp(iter->name, "33"));
+		assert(! strcmp(iter->value, "three three"));
+
+		assert(iter == formvars_last);
+		assert(! (iter = iter->next));
+
+		cgi_end();
+	}
+}
+
+void
+test_cgi_param_multiple(void)
+{
+	const char *data = "zero=0&one=one&one=two&two=three&one=four&three=3";
+
+	process_data(data, &formvars_start, &formvars_last, '=', '&');
+
+	assert(! strcmp(cgi_param_multiple("one"), "one"));
+	assert(! strcmp(cgi_param_multiple("one"), "two"));
+	assert(! strcmp(cgi_param_multiple("one"), "four"));
+	assert(! cgi_param_multiple("one"));
+
+	cgi_end();
+}
+
+
+/*****************************************************************************/
+
+int
+main(void)
+{
+	test_cgi_escape_special_chars();
+	test_process_data();
+	test_cgi_param_multiple();
+
+	puts("Tests passed.");
+	return 0;
+}
+

--- a/test/test.c
+++ b/test/test.c
@@ -9,14 +9,16 @@
 #include "cgi.h"
 
 extern formvars *
-process_data(char *query, formvars **start, formvars **last,
-             const char delim, const char sep);
+process_data(const char *query, formvars **start, formvars **last,
+             const char sep_value, const char sep_name);
 
 static int pipe_[2];
 
 static void
 test_cgi_escape_special_chars(void)
 {
+    puts(__FUNCTION__);
+
 	const char *esc_valid = "%._-+0123456789"
 	                        "abcdefghijklmnopqrstuvwxyz"
 	                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -40,6 +42,8 @@ test_cgi_escape_special_chars(void)
 static void
 test_process_data(void)
 {
+    puts(__FUNCTION__);
+
 	formvars *fvp, *iter;
 	const char *data[] = {"1=one&second=%20.two-%30&33=three+three",
 	                      "&1=one&second=%20.two-%30&33=three+three",
@@ -79,6 +83,8 @@ test_process_data(void)
 void
 test_cgi_param_multiple(void)
 {
+    puts(__FUNCTION__);
+
 	const char *data = "zero=0&one=one&one=two&two=three&one=four&three=3";
 
 	process_data(data, &formvars_start, &formvars_last, '=', '&');
@@ -114,6 +120,8 @@ _post(const char *post_data)
 void
 test_cgi_process_form(void)
 {
+    puts(__FUNCTION__);
+
 	/* test no data */
 	assert(formvars_start == NULL);
 	assert(formvars_last == NULL);
@@ -151,6 +159,67 @@ test_cgi_process_form(void)
 	cgi_end();
 }
 
+static void
+_test_ltrim(void)
+{
+    puts(__FUNCTION__);
+
+    char before[][15] = {   "   test1",
+                            "",
+                            " ",
+                            "        test",
+                            "\nexample",
+                            "\r\nline"      };
+    char after[][15] =  {   "test1",
+                            "",
+                            "",
+                            "test",
+                            "example",
+                            "line"          };
+    size_t  n = sizeof(before) / 15;
+
+    char buf[30];
+    while (n)
+    {
+        --n;
+        strcpy(buf, before[n]);
+        cgi_ltrim(buf);
+        assert(! strcmp(buf, after[n]));
+    }
+}
+
+static void
+_test_rtrim(void)
+{
+    puts(__FUNCTION__);
+
+    char before[][10] = {   "test1",
+                            "",
+                            " ",
+                            "test    ",
+                            "example\n",
+                            "line\r\n"      };
+    char after[][10] =  {   "test1",
+                            "",
+                            "",
+                            "test",
+                            "example",
+                            "line"          };
+    size_t  n = sizeof(before) / 10;
+
+    char buf[30];
+    while (n)
+    {
+        --n;
+        strcpy(buf, before[n]);
+        cgi_rtrim(buf);
+        assert(! strcmp(buf, after[n]));
+
+        strcpy(buf, before[n]);
+        cgi_rtrim(buf);
+        assert(! strcmp(buf, after[n]));
+    }
+}
 
 
 /*****************************************************************************/
@@ -167,6 +236,9 @@ main(void)
 	test_process_data();
 	test_cgi_param_multiple();
 	test_cgi_process_form();
+
+	_test_ltrim();
+	_test_rtrim();
 
 	puts("Tests passed.");
 	return 0;

--- a/test/test.c
+++ b/test/test.c
@@ -7,6 +7,10 @@
 
 #include "cgi.h"
 
+extern formvars *
+process_data(char *query, formvars **start, formvars **last,
+             const char delim, const char sep);
+
 static void
 test_cgi_escape_special_chars(void)
 {
@@ -84,6 +88,34 @@ test_cgi_param_multiple(void)
 	cgi_end();
 }
 
+void
+test_cgi_process_form(void)
+{
+	/* test no data */
+	assert(formvars_start == NULL);
+	assert(formvars_last == NULL);
+
+	assert(! putenv("QUERY_STRING"));
+	assert(! cgi_process_form());
+
+	assert(! formvars_start && ! formvars_last);
+	cgi_end();
+
+	/* test query string */
+	assert(formvars_start == NULL);
+	assert(formvars_last == NULL);
+
+	assert(! putenv("QUERY_STRING=zero=0&one=one"));
+	assert(cgi_process_form());
+
+	assert(formvars_start && formvars_last);
+	assert(! strcmp(formvars_start->name, "zero"));
+	assert(! strcmp(formvars_start->value, "0"));
+
+	cgi_end();
+}
+
+
 
 /*****************************************************************************/
 
@@ -93,6 +125,7 @@ main(void)
 	test_cgi_escape_special_chars();
 	test_process_data();
 	test_cgi_param_multiple();
+	test_cgi_process_form();
 
 	puts("Tests passed.");
 	return 0;

--- a/test/test.c
+++ b/test/test.c
@@ -54,7 +54,7 @@ int test_cgi_escape_special_chars( void )
 	                        "abcdefghijklmnopqrstuvwxyz"
 	                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	char str[256];
-	char *esc, *unesc;
+	char *esc = NULL, *unesc = NULL;
 	int c;
 
 	for (c = 0; c < 256; ++c)
@@ -68,6 +68,8 @@ int test_cgi_escape_special_chars( void )
 	check( !strcmp(str, unesc), "strcmp str unesc" );
 	check( strspn(esc, esc_valid) == strlen(esc), "strspn" );
 
+	free( esc );
+	free( unesc );
 	return EXIT_SUCCESS;
 
 error:

--- a/test/test_trim.c
+++ b/test/test_trim.c
@@ -1,0 +1,136 @@
+/*******************************************************************//**
+ *	@file	test_trim.c
+ *
+ *	Test different trim implementations.
+ *
+ *	@author	Alexander Dahl <post@lespocky.de>
+ *
+ *	Copyright 2017 Alexander Dahl
+ **********************************************************************/
+
+#include <stddef.h>
+#include <string.h>
+
+#include "cgi_test.h"
+
+#include "cgi.h"
+
+/*	trim.c	*/
+char* ltrim(char* s);
+char* rtrim( char* s);
+char*  trim( char* s);
+
+/*	local declarations	*/
+static int test_ltrim( void );
+static int test_rtrim( void );
+static int test_trim( void );
+
+static const char *test_strings[] = {
+	"   test1",
+	"",
+	" ",
+	"        test",
+	"\nexample",
+	"\r\nline"
+	"test1",
+	"test    ",
+	"example\n",
+	"line\r\n",
+	" \tfoo",
+	"\tbar  \n",
+	"\n\n",
+	"\rbaz\r",
+	NULL
+};
+
+int main( int argc, char *argv[] )
+{
+	struct cgi_test_action	actions[] = {
+		{ "ltrim",	test_ltrim	},
+		{ "rtrim",	test_rtrim	},
+		{ "trim",	test_trim	},
+	};
+
+	/*	require at least one argument to select test	*/
+	if ( argc < 2 ) return EXIT_FAILURE;
+
+	return run_action( argv[1], actions,
+			sizeof(actions)/sizeof(struct cgi_test_action) );
+}
+
+int test_ltrim( void )
+{
+	char		*str_1, *str_2;
+	const char	**test_str;
+
+	for ( test_str = test_strings; *test_str; test_str++ )
+	{
+		check( (str_1 = strdup( *test_str )), "strdup failed" );
+		check( (str_2 = strdup( *test_str )), "strdup failed" );
+
+		check( cgi_ltrim( str_1 ) == str_1, "cgi_ltrim" );
+		check( ltrim( str_2) == str_2, "ltrim" );
+
+		check( !strcmp( str_1, str_2 ), "strcmp" );
+
+		free( str_1 );
+		free( str_2 );
+	}
+
+	return EXIT_SUCCESS;
+
+error:
+	return EXIT_FAILURE;
+}
+
+int test_rtrim( void )
+{
+	char		*str_1, *str_2;
+	const char	**test_str;
+
+	for ( test_str = test_strings; *test_str; test_str++ )
+	{
+		check( (str_1 = strdup( *test_str )), "strdup failed" );
+		check( (str_2 = strdup( *test_str )), "strdup failed" );
+
+		check( cgi_rtrim( str_1 ) == str_1, "cgi_rtrim" );
+		check( rtrim( str_2) == str_2, "rtrim" );
+
+		check( !strcmp( str_1, str_2 ), "strcmp" );
+
+		free( str_1 );
+		free( str_2 );
+	}
+
+	return EXIT_SUCCESS;
+
+error:
+	return EXIT_FAILURE;
+}
+
+int test_trim( void )
+{
+	char		*str_1, *str_2;
+	const char	**test_str;
+
+	for ( test_str = test_strings; *test_str; test_str++ )
+	{
+		check( (str_1 = strdup( *test_str )), "strdup failed" );
+		check( (str_2 = strdup( *test_str )), "strdup failed" );
+
+		check( cgi_trim( str_1 ) == str_1, "cgi_trim" );
+		check( trim( str_2) == str_2, "trim" );
+
+		check( !strcmp( str_1, str_2 ), "strcmp" );
+
+		free( str_1 );
+		free( str_2 );
+	}
+
+	return EXIT_SUCCESS;
+
+error:
+	return EXIT_FAILURE;
+}
+
+/* vim: set noet sts=0 ts=4 sw=4 sr: */

--- a/test/trim.c
+++ b/test/trim.c
@@ -1,0 +1,49 @@
+#include <ctype.h>
+#include <string.h>
+
+/*
+ *	Public domain implementations of in-place string trim functions
+ *
+ *	2010 Michael Burr <michael.burr@nth-element.com>
+ *
+ *	see https://stackoverflow.com/questions/122616/how-do-i-trim-leading-trailing-whitespace-in-a-standard-way/2452438#2452438
+ */
+
+char* ltrim(char* s)
+{
+    char* newstart = s;
+
+    while (isspace( *newstart)) {
+        ++newstart;
+    }
+
+    // newstart points to first non-whitespace char (which might be '\0')
+    memmove( s, newstart, strlen( newstart) + 1); // don't forget to move the '\0' terminator
+
+    return s;
+}
+
+
+char* rtrim( char* s)
+{
+    char* end = s + strlen( s);
+
+    // find the last non-whitespace character
+    while ((end != s) && isspace( *(end-1))) {
+            --end;
+    }
+
+    // at this point either (end == s) and s is either empty or all whitespace
+    //      so it needs to be made empty, or
+    //      end points just past the last non-whitespace character (it might point
+    //      at the '\0' terminator, in which case there's no problem writing
+    //      another there).
+    *end = '\0';
+
+    return s;
+}
+
+char*  trim( char* s)
+{
+    return rtrim( ltrim( s));
+}


### PR DESCRIPTION
This adds several old and new test stuff:

* let CTest execute tests again with valgrind, if valgrind is installed
* import tests by @DFrostByte squashed together in meaningful chunks and make those usable with CTest
* fix some memory leaks in the tests
* add additional tests for trim (revealed the flaw in #16)
* replace some assert() calls with the check() macro