### PR TITLE
CMakeLists.txt: libcgi is in C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 cmake_minimum_required(VERSION 2.8.8)
 
-project(cgi)
+project(cgi C)
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UC)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LC)
 set(LIBPREFIX ${PROJECT_NAME})


### PR DESCRIPTION
By default, CMake checks that both C and C++ compilers are
available. However, since libcgi is only C, there's no need for a C++
compiler check. Therefore, this commit adjusts the project() variable
definition to only require C language support.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>