### PR TITLE
CMakeLists.txt: don't force the build of a shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,17 +23,18 @@ set(CGI_SRC
 )
 
 # create binary
-add_library(${PROJECT_NAME}-shared SHARED ${CGI_SRC})
-set_target_properties(${PROJECT_NAME}-shared PROPERTIES
+add_library(${PROJECT_NAME} ${CGI_SRC})
+set_target_properties(${PROJECT_NAME} PROPERTIES
 	OUTPUT_NAME	${PROJECT_NAME}
 	SOVERSION	${PROJECT_VERSION_MAJOR}
 	VERSION		${PROJECT_VERSION}
 )
 
 # install binary
-install(TARGETS ${PROJECT_NAME}-shared
+install(TARGETS ${PROJECT_NAME}
 	EXPORT ${PROJECT_NAME}-targets
 	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )
 
 # install cmake targets

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(cgi-test
 	test.c
 )
 target_link_libraries(cgi-test
-	"${PROJECT_NAME}-shared"
+	"${PROJECT_NAME}"
 )
 add_test(escape_special_chars
 	cgi-test escape_special_chars
@@ -39,7 +39,7 @@ add_executable(cgi-test-slist
 	test_slist.c
 )
 target_link_libraries(cgi-test-slist
-	"${PROJECT_NAME}-shared"
+	"${PROJECT_NAME}"
 )
 add_test(slist_add
 	cgi-test-slist add
@@ -70,7 +70,7 @@ add_executable(cgi-test-trim
 	trim.c
 )
 target_link_libraries(cgi-test-trim
-	"${PROJECT_NAME}-shared"
+	"${PROJECT_NAME}"
 )
 add_test(test_ltrim
 	cgi-test-trim ltrim


### PR DESCRIPTION
Building a shared library doesn't work on all platforms, so instead,
let CMake rely on the standard BUILD_SHARED_LIBS variable to decide
whether a static or shared library should be built.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>