### PR TITLE
Use modern CMake features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,17 @@
 #
-# Copyright 2013,2016,2017 Alexander Dahl <post@lespocky.de>
+# Copyright 2013,2016–2018 Alexander Dahl <post@lespocky.de>
 #
-cmake_minimum_required(VERSION 2.8.8)
 
-project(cgi C)
+cmake_minimum_required(VERSION 3.1)
+
+project(cgi
+	VERSION 1.1.1
+	LANGUAGES C
+)
+message(STATUS "cgi_VERSION: ${cgi_VERSION}")
+
 string(TOUPPER ${PROJECT_NAME} PROJECT_NAME_UC)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LC)
-set(LIBPREFIX ${PROJECT_NAME})
-set(LIBPREFIX_LC ${PROJECT_NAME_LC})
-set(LIBPREFIX_UC ${PROJECT_NAME_UC})
-
-set(PROJECT_VERSION_MAJOR 1)
-set(PROJECT_VERSION_MINOR 1)
-set(PROJECT_VERSION_PATCH 0)
-if(PROJECT_VERSION_PATCH EQUAL 0)
-set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
-else(PROJECT_VERSION_PATCH EQUAL 0)
-set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-endif(PROJECT_VERSION_PATCH EQUAL 0)
-message(STATUS "PROJECT_VERSION: ${PROJECT_VERSION}")
 
 set(CGI_DESCRIPTION "A C library to build CGI applications.")
 set(CGI_URL "https://github.com/rafaelsteil/libcgi")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ include(GNUInstallDirs)				# cmake 2.8.5
 
 # options
 option(BUILD_SHARED_LIBS
-    "Global flag to cause add_library to create shared libraries if on."
-    ON
+	"Global flag to cause add_library to create shared libraries if on."
+	ON
 )
 
 # subdirectories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,6 @@ include(CMakePackageConfigHelpers)	# cmake 2.8.8
 include(FeatureSummary)
 include(GNUInstallDirs)				# cmake 2.8.5
 
-# additional compiler flags
-add_definitions(-Wall -Wextra -Wcast-align)
-
 # options
 option(BUILD_SHARED_LIBS
     "Global flag to cause add_library to create shared libraries if on."

--- a/cgi-config.cmake.in
+++ b/cgi-config.cmake.in
@@ -1,5 +1,5 @@
 #
-# Copyright 2013,2016,2017 Alexander Dahl <post@lespocky.de>
+# Copyright 2013,2016–2018 Alexander Dahl <post@lespocky.de>
 #
 
 # paths
@@ -8,10 +8,10 @@ set_and_check(CGI_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/lib@PROJECT_N
 
 # targets
 get_filename_component(_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
-if(NOT TARGET @PROJECT_NAME@)
+if(NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
 	include("${_dir}/@PROJECT_NAME@-targets.cmake")
-endif(NOT TARGET @PROJECT_NAME@)
-set(CGI_LIBRARIES @PROJECT_NAME@)
+endif(NOT TARGET @PROJECT_NAME@::@PROJECT_NAME@)
+set(CGI_LIBRARIES @PROJECT_NAME@::@PROJECT_NAME@)
 
 # feature summary
 include(FeatureSummary)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,10 @@
 #
-# Copyright 2013,2016 Alexander Dahl <post@lespocky.de>
+# Copyright 2013,2016,2018 Alexander Dahl <post@lespocky.de>
 #
+
 configure_file(
 	"${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake.in"
 	"${CMAKE_CURRENT_BINARY_DIR}/config.h"
-)
-
-include_directories(
-	"${CMAKE_CURRENT_BINARY_DIR}"
 )
 
 set(CGI_SRC
@@ -28,6 +25,13 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 	OUTPUT_NAME	${PROJECT_NAME}
 	SOVERSION	${PROJECT_VERSION_MAJOR}
 	VERSION		${PROJECT_VERSION}
+)
+
+target_include_directories(${PROJECT_NAME}
+	PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+		$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # install binary

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,8 @@ set(CGI_SRC
 
 # create binary
 add_library(${PROJECT_NAME} ${CGI_SRC})
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
 	OUTPUT_NAME	${PROJECT_NAME}
 	SOVERSION	${PROJECT_VERSION_MAJOR}
@@ -43,6 +45,7 @@ install(TARGETS ${PROJECT_NAME}
 
 # install cmake targets
 install(EXPORT ${PROJECT_NAME}-targets
+	NAMESPACE ${PROJECT_NAME}::
 	DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,6 @@
 #
-# Copyright 2016,2017 Alexander Dahl <post@lespocky.de>
+# Copyright 2016–2018 Alexander Dahl <post@lespocky.de>
 #
-
-include_directories(
-	"${PROJECT_SOURCE_DIR}/src"
-)
 
 # misc
 add_executable(cgi-test
@@ -12,7 +8,7 @@ add_executable(cgi-test
 	test.c
 )
 target_link_libraries(cgi-test
-	"${PROJECT_NAME}"
+	${PROJECT_NAME}
 )
 add_test(escape_special_chars
 	cgi-test escape_special_chars
@@ -39,7 +35,7 @@ add_executable(cgi-test-slist
 	test_slist.c
 )
 target_link_libraries(cgi-test-slist
-	"${PROJECT_NAME}"
+	${PROJECT_NAME}
 )
 add_test(slist_add
 	cgi-test-slist add
@@ -70,7 +66,7 @@ add_executable(cgi-test-trim
 	trim.c
 )
 target_link_libraries(cgi-test-trim
-	"${PROJECT_NAME}"
+	${PROJECT_NAME}
 )
 add_test(test_ltrim
 	cgi-test-trim ltrim


### PR DESCRIPTION
These are changes for the "Modern CMake" approach everyone talks about recently. See [Getting CDash to work on Debian 9 (stretch) with lighttpd and MariaDB](http://blog.antiblau.de/2018/07/09/getting-cdash-to-work-on-debian-9-stretch-with-lighttpd-and-mariadb/) for further reading and resources on that topic.