### PR TITLE
examples: Fix include paths

### DIFF
--- a/examples/guestbook/gbook.c
+++ b/examples/guestbook/gbook.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <time.h>
-#include <cgi.h>
+
+#include <libcgi/cgi.h>
 
 // File to write the messages
 #define GBOOK "/tmp/libcgi_gbook.html"
@@ -33,9 +34,9 @@ void example_description()
 }
 
 int main()
-{	
+{
 	cgi_init();
-	cgi_process_form();	
+	cgi_process_form();
 	cgi_init_headers();
 
 	example_description();
@@ -45,7 +46,7 @@ int main()
 		FILE *fp;
 
 		fp = fopen(GBOOK, "a");
-		if (!fp) 
+		if (!fp)
 			cgi_fatal("Failed to open guestbook file for appending");
 
 		fseek(fp, 0, SEEK_SET);
@@ -65,7 +66,7 @@ int main()
 	show_comments();
 
 	puts("</td></tr></table></body></html>");
-	
+
 	cgi_end();
 	return 0;
 }

--- a/examples/multiple/multiple.c
+++ b/examples/multiple/multiple.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
-#include <cgi.h>
+
+#include <libcgi/cgi.h>
 
 void example_description()
 {
@@ -12,7 +13,7 @@ void example_description()
 int main(void)
 {
 	char *data;
-		
+
 	cgi_init();
 	cgi_init_headers();
 	cgi_process_form();
@@ -23,7 +24,7 @@ int main(void)
 		while ((data = cgi_param_multiple("check")) != NULL)
 			printf("%s<br>", data);
 	}
-	else 
+	else
 		cgi_include("form.html");
 
 	cgi_end();

--- a/examples/redirect/redirect.c
+++ b/examples/redirect/redirect.c
@@ -1,6 +1,6 @@
-
 #include <stdio.h>
-#include "cgi.h"
+
+#include <libcgi/cgi.h>
 
 void example_description()
 {
@@ -16,7 +16,7 @@ int main()
 
 	if (cgi_param("url"))
 		cgi_redirect(cgi_param("url"));
-	
+
 	cgi_init_headers();
 
 	example_description();
@@ -31,7 +31,7 @@ int main()
 	"</form>"
 	"</body>"
 	"</html>");
-	
+
 	cgi_end();
 
 	return 0;

--- a/examples/session/session_ex1/destroy.c
+++ b/examples/session/session_ex1/destroy.c
@@ -1,7 +1,8 @@
 #include <stdio.h>
-#include <cgi.h>
-#include <session.h>
 #include <string.h>
+
+#include <libcgi/cgi.h>
+#include <libcgi/session.h>
 
 int main(void)
 {
@@ -12,7 +13,7 @@ int main(void)
 	// Is to destroy the session?
 	if (cgi_param("confirm") && !strcmp(cgi_param("confirm"), "yes")) {
 		cgi_session_destroy();
-		cgi_end();		
+		cgi_end();
 		cgi_redirect("session.cgi");
 		return 0;
 	}
@@ -27,7 +28,7 @@ int main(void)
 	"");
 
 	cgi_include("session_ex1_desc.html");
-	
+
 	puts(""
 	"<table width='70%%' align='center'>"
 	"<tr>"
@@ -58,4 +59,4 @@ int main(void)
 
 	return 0;
 }
-		
+

--- a/examples/session/session_ex1/login.c
+++ b/examples/session/session_ex1/login.c
@@ -1,13 +1,14 @@
 #include <stdio.h>
-#include <cgi.h>
-#include <session.h>
+
+#include <libcgi/cgi.h>
+#include <libcgi/session.h>
 
 int main(void)
 {
 	cgi_init();
 	cgi_session_start();
 	cgi_process_form();
-	
+
 	// The user is trying to logon?
 	if (cgi_param("action")) {
 		// yeah!
@@ -18,7 +19,7 @@ int main(void)
 		// Sends the user to main page
 		cgi_redirect("session.cgi");
 		cgi_end();
-		
+
 		return 0;
 	}
 
@@ -38,7 +39,7 @@ int main(void)
 	"<tr>"
 	"<td>"
 	"");
-	
+
 	if (!cgi_session_var_exists("logged")) {
 		puts(""
 		"<form action='login.cgi' method='get'>"

--- a/examples/session/session_ex1/restricted.c
+++ b/examples/session/session_ex1/restricted.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
-#include <cgi.h>
-#include <session.h>
+
+#include <libcgi/cgi.h>
+#include <libcgi/session.h>
 
 int main(void)
 {
 	char *name, *value;
-	
+
 	cgi_init();
 	cgi_session_start();
 	cgi_process_form();

--- a/examples/session/session_ex1/session.c
+++ b/examples/session/session_ex1/session.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
-#include <cgi.h>
-#include <session.h>
+
+#include <libcgi/cgi.h>
+#include <libcgi/session.h>
 
 int main(void)
 {
@@ -10,7 +11,7 @@ int main(void)
 
 	puts("<html><body>");
 	cgi_include("session_ex1_desc.html");
-	
+
 	puts(""
 	"<table width='70%%' align='center'>"
 	"<tr>"
@@ -19,7 +20,7 @@ int main(void)
 	"");
 
 	// The user is logged?
-	if (cgi_session_var_exists("logged")) 
+	if (cgi_session_var_exists("logged"))
 		puts(" - logged");
 	else
 		puts(" - not logged yet");

--- a/examples/session/session_ex1/show_vars.c
+++ b/examples/session/session_ex1/show_vars.c
@@ -1,15 +1,16 @@
 #include <stdio.h>
-#include <cgi.h>
+
+#include <libcgi/cgi.h>
 
 int main(void)
 {
 	// formvars is a structure type used to manage session and cgi
-	// linked lists. It have 'name' and 'value' properties. 
+	// linked lists. It have 'name' and 'value' properties.
 	formvars *sess_vars;
 	char *data;
-	
+
 	cgi_init();
-	cgi_session_start();	
+	cgi_session_start();
 	cgi_process_form();
 
 	// The user is trying to unregister some variables?
@@ -44,10 +45,10 @@ int main(void)
 	}
 	else {
 		// show the registered session variables to user
-		// sess_list_start is a global variable that contains 
+		// sess_list_start is a global variable that contains
 		// all session variables information, such name and value
 		sess_vars = sess_list_start;
-		
+
 		puts("<form action='show_vars.cgi' method='post'>");
 
 		while (sess_vars) {

--- a/examples/session/session_ex2/Makefile
+++ b/examples/session/session_ex2/Makefile
@@ -1,13 +1,13 @@
 CC = gcc
-FLAGS = -Wall
+FLAGS = -Wall -g
 CGIBIN = .
 
 all:
 	$(CC) $(FLAGS) -lcgi session_ex2.c -o $(CGIBIN)/session_ex2.cgi
 
-	@echo 
+	@echo
 	@echo Example compiled.
-	@echo Now copy *.cgi and *.html 
+	@echo Now copy *.cgi and *.html
 	@echo to your webserver cgi-bin directory, create a directory called
 	@echo \"session_files\" there, give permission to the webserver\'s user
 	@echo and call session_ex2.cgi application to test LibCGI session support

--- a/examples/session/session_ex2/session_ex2.c
+++ b/examples/session/session_ex2/session_ex2.c
@@ -2,13 +2,13 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <cgi.h>
-#include <session.h>
+#include <libcgi/cgi.h>
+#include <libcgi/session.h>
 
 int main()
 {
 	char *action;
-	
+
 	cgi_init();
 	cgi_process_form();
 
@@ -38,11 +38,11 @@ int main()
 
 	// includes the description for this example
 	cgi_include("session_ex2_desc.html");
-  	
+
 	// The user is logged?
 	if (cgi_session_var_exists("str")) {
 		// yep, let's show him some things
-		
+
 		printf(""
 		"<br><b>Congratulations, you've logged</b><br>"
 		"If you want to finish the session, <a href='session_ex2.cgi?action=logoff'>click here</a>!"
@@ -59,7 +59,7 @@ int main()
 			"	<input type='hidden' name='action' value='login'>"
 			"</form>"
 		"");
-	}		
+	}
 
 	// Print session configuration directives
 	printf("Session configuration options: <br>"

--- a/examples/simple_form/form1.c
+++ b/examples/simple_form/form1.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
-#include "cgi.h"
+
+#include <libcgi/cgi.h>
 
 void example_description()
 {
@@ -33,7 +34,7 @@ int main(void)
 	      "  <tbody>"
 	"	  <tr>"
 	"");
-	
+
 	cgi_include("top.inc");
 	cgi_include("left.inc");
 	cgi_include("main.inc");
@@ -45,7 +46,7 @@ int main(void)
 	   "</body>"
 	   "</html>"
 	"");
-	
+
 	cgi_end();
 
 	return 0;

--- a/examples/simple_form/form2.c
+++ b/examples/simple_form/form2.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
-#include "cgi.h"
+
+#include <libcgi/cgi.h>
 
 int main(void)
 {
@@ -17,7 +18,7 @@ int main(void)
 	 "   <meta name='author' content='Rafael Steil'>"
 	  "    <title>LIBCGI Examples</title>"
 	   "   </head>"
-	   "  <body text='#000000' bgcolor='#ffffff' link='#0000ee' vlink='#551a8b' alink='#0000ee'>"		
+	   "  <body text='#000000' bgcolor='#ffffff' link='#0000ee' vlink='#551a8b' alink='#0000ee'>"
 	"");
 
 	// NAME
@@ -44,9 +45,9 @@ int main(void)
 	puts(""
 	"</body>"
 	"</html>"
-	"");	
+	"");
 
 	cgi_end();
-	
+
 	return 0;
 }

--- a/examples/strings/b64.c
+++ b/examples/strings/b64.c
@@ -1,47 +1,46 @@
 #include <stdio.h>
-#include <cgi.h>
 #include <string.h>
 #include <stdlib.h>
 
+#include <libcgi/cgi.h>
+
 char *example_description()
 {
-	char *desc = "
-	LibCGI examples, str_base64_* functions demostration. <br>
-	";
-	
+	char *desc = "LibCGI examples, str_base64_* functions demostration. <br>";
+
 	return desc;
 }
 
 int main()
 {
 	char *to_encode, *to_decode;
-	
+
 	cgi_init();
 	cgi_process_form();
 	cgi_init_headers();
-	
+
 	if (cgi_param("action")) {
 		to_encode = cgi_param("encode");
 		to_decode = cgi_param("decode");
-		
+
 		// First check if we need to encode some string
 		if (to_encode) {
 			printf("<i>str_base64_encode()</i> example: original string: <b>%s</b><br>"
 			"Encoded string: <b>%s</b><br><br>", to_encode, str_base64_encode(to_encode));
 		}
-		
+
 		// Now if is to decode
 		if (to_decode) {
 			printf("<i>str_base64_decode()</i> example: original encoded string: <b>%s</b><br>"
-			"Decoded string: <b>%s</b><br><br>", to_decode, str_base64_decode(to_decode));		
+			"Decoded string: <b>%s</b><br><br>", to_decode, str_base64_decode(to_decode));
 		}
-		
+
 		puts("<hr>");
 
 		free(to_encode);
 		free(to_decode);
 	}
-	
+
 	printf(""
 	"<html><head><title>LibCGI examples - str_base64_*()</title></head>"
 	"<body>"
@@ -54,7 +53,7 @@ int main()
 	"</body>"
 	"</html>"
 	"", example_description());
-	
+
 	cgi_end();
 	return 0;
 }

--- a/examples/strings/explode.c
+++ b/examples/strings/explode.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <cgi.h>
+
+#include <libcgi/cgi.h>
 
 char *example_description()
 {
@@ -10,34 +11,34 @@ char *example_description()
 	"like to use, and then click the submit button to split the<br>"
 	"string in pieces."
 	"";
-	
+
 	return desc;
 }
 
 int main()
 {
 	char *str, *delim, **e;
-	
+
 	unsigned int total, i;
-	
+
 	cgi_init();
 	cgi_process_form();
 	cgi_init_headers();
-	
+
 	// The form was submited??
 	if (cgi_param("action")) {
 		str = cgi_param("str");
 		delim = cgi_param("delim");
-		
+
 		e = explode(str, delim, &total);
-		
+
 		if (total < 1)
 			puts("explode() returned 0 items.");
 		else {
 			for (i = 0; i < total; i++)
 				printf("Item offset [%d]: %s<br>", i, e[i]);
 		}
-		
+
 		free(str);
 		free(delim);
 	}
@@ -55,8 +56,8 @@ int main()
 		"</html>"
 		"", example_description());
 	}
-	
+
 	cgi_end();
 	return 0;
 }
-	
+

--- a/examples/strings/htmlentities.c
+++ b/examples/strings/htmlentities.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
-#include <cgi.h>
+
+#include <libcgi/cgi.h>
 
 char *example_description()
 {
@@ -7,20 +8,20 @@ char *example_description()
 	"LibCGI examples, htmltities() function demostration. <br>"
 	"Type an html code into textarea and then click OK"
 	"";
-	
+
 	return desc;
 }
 
 int main()
 {
 	char *q;
-	
+
 	cgi_init();
 	cgi_process_form();
 	cgi_init_headers();
-	
+
 	q = cgi_param("q");
-	
+
 	if (q)
 		puts(htmlentities(q));
 	else {
@@ -34,9 +35,9 @@ int main()
 		"</form>"
 		"</body>"
 		"</html>"
-		"", example_description());	
+		"", example_description());
 	}
-	
+
 	cgi_end();
 	return 0;
 }

--- a/examples/strings/md5.c
+++ b/examples/strings/md5.c
@@ -1,37 +1,38 @@
 #include <stdio.h>
-#include <cgi.h>
 #include <string.h>
 #include <stdlib.h>
+
+#include <libcgi/cgi.h>
 
 char *example_description()
 {
 	char *desc = "LibCGI examples, md5 function demostration. <br>";
-	
+
 	return desc;
 }
 
 int main()
 {
 	char *to_encode;
-	
+
 	cgi_init();
 	cgi_process_form();
 	cgi_init_headers();
-	
+
 	if (cgi_param("action")) {
 		to_encode = cgi_param("encode");
-		
+
 		// First check if we need to encode some string
 		if (to_encode) {
 			printf("<i>md5()</i> example: original string: <b>%s</b><br>"
 			"Encoded string: <b>%s</b><br><br>", to_encode, md5(to_encode));
 		}
-		
+
 		puts("<hr>");
 
 		free(to_encode);
 	}
-	
+
 	printf("<html><head><title>LibCGI examples - md5()</title></head>"
 	"<body>"
 	"%s<br><br>"
@@ -42,7 +43,7 @@ int main()
 	"</body>"
 	"</html>"
 	"", example_description());
-	
+
 	cgi_end();
 	return 0;
 }


### PR DESCRIPTION
The include paths for the installed headers were harmonized between the
old autotools based build and the new CMake based one with commit
b24b4ba959324fd1db44c0edce03d5bd3248fc12. This path should
stay as is and the examples should show how to use it.

All examples build with the provided makefiles, I did not check if it
makes sense in any way, what those examples do.

Signed-off-by: Alexander Dahl <post@lespocky.de>