### PR TITLE
Fix segfault on cgi_unescape_special_chars() and provide unit test for that case

### DIFF
--- a/src/cgi.c
+++ b/src/cgi.c
@@ -436,7 +436,9 @@ char *cgi_unescape_special_chars(const char *str)
 	char c;
 	char hex[2];
 
-	new = (char *)malloc(strlen(str) + 1);
+	if ( !str ) return NULL;
+
+	new = (char *) calloc( strlen(str) + 1, 1 );
 	if (! new)
 		libcgi_error(E_MEMORY, "%s, line %s", __FILE__, __LINE__);
 

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -19,6 +19,7 @@
     You can contact the author by e-mail: rafael@insanecorp.com
 */
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,9 @@ add_test(NAME cgi_rtrim
 add_test(NAME cgi_version
 	COMMAND cgi-test version
 )
+add_test(NAME cgi_unescape_special_chars
+	COMMAND cgi-test unescape_special_chars
+)
 
 # slist
 add_executable(cgi-test-slist

--- a/test/test.c
+++ b/test/test.c
@@ -25,6 +25,7 @@ static int test_cgi_process_form( void );
 static int _test_ltrim( void );
 static int _test_rtrim( void );
 static int version( void );
+static int unescape_special_chars( void );
 
 int main( int argc, char *argv[] )
 {
@@ -36,6 +37,7 @@ int main( int argc, char *argv[] )
 		{ "ltrim",					_test_ltrim						},
 		{ "rtrim",					_test_rtrim						},
 		{ "version",				version							},
+		{ "unescape_special_chars",	unescape_special_chars			},
 	};
 
 	/*	require at least one argument to select test	*/
@@ -319,6 +321,15 @@ int version( void )
 {
 	check( 0 == strcmp( CGI_VERSION, cgi_version() ),
 			"strcmp( '%s', '%s' )", CGI_VERSION, cgi_version() );
+
+	return EXIT_SUCCESS;
+error:
+	return EXIT_FAILURE;
+}
+
+int unescape_special_chars( void )
+{
+	check( NULL == cgi_unescape_special_chars( NULL ), "null" );
 
 	return EXIT_SUCCESS;
 error:


### PR DESCRIPTION
I had a change in my Git stash lying around which fixes an actual segfault and I didn't want to just drop it.