### PR TITLE
Move type definitions from cgi.h to separate file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.1)
 
 project(cgi
-	VERSION 1.2.0
+	VERSION 1.2.1
 	LANGUAGES C
 )
 message(STATUS "cgi_VERSION: ${cgi_VERSION}")

--- a/include/libcgi/CMakeLists.txt
+++ b/include/libcgi/CMakeLists.txt
@@ -12,6 +12,7 @@ configure_file(
 
 install(FILES
 	cgi.h
+	cgi_types.h
 	error.h
 	session.h
 	DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/libcgi"

--- a/include/libcgi/cgi.h
+++ b/include/libcgi/cgi.h
@@ -12,6 +12,8 @@
 
 #include <stdio.h>
 
+#include <libcgi/cgi_types.h>
+
 #if defined(__GNUC__)
 #define CGI_DEPRECATED __attribute__ ((deprecated))
 #elif defined(_MSC_VER)
@@ -23,71 +25,9 @@
 #define CGI_DEPRECATED
 #endif
 
-/**
- *	HTTP status codes.
- *
- *	@see	http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
- */
-enum cgi_http_status_code {
-	HTTP_STATUS_CONTINUE			= 100,
-	HTTP_STATUS_SWITCHING_PROTOCOLS	= 101,
-
-	HTTP_STATUS_OK					= 200,
-	HTTP_STATUS_CREATED				= 201,
-	HTTP_STATUS_ACCEPTED			= 202,
-	HTTP_STATUS_NON_AUTH_INFO		= 203,
-	HTTP_STATUS_NO_CONTENT			= 204,
-	HTTP_STATUS_RESET_CONTENT		= 205,
-	HTTP_STATUS_PARTIAL_CONTENT		= 206,
-
-	HTTP_STATUS_MULTIPLE_CHOICES	= 300,
-	HTTP_STATUS_MOVED_PERMANENTLY	= 301,
-	HTTP_STATUS_FOUND				= 302,
-	HTTP_STATUS_SEE_OTHER			= 303,
-	HTTP_STATUS_NOT_MODIFIED		= 304,
-	HTTP_STATUS_USE_PROXY			= 305,
-	HTTP_STATUS_TEMPORARY_REDIRECT	= 307,
-
-	HTTP_STATUS_BAD_REQUEST			= 400,
-	HTTP_STATUS_UNAUTHORIZED		= 401,
-	HTTP_STATUS_PAYMENT_REQUIRED	= 402,
-	HTTP_STATUS_FORBIDDEN			= 403,
-	HTTP_STATUS_NOT_FOUND			= 404,
-	HTTP_STATUS_METHOD_NOT_ALLOWED	= 405,
-	HTTP_STATUS_NOT_ACCEPTABLE		= 406,
-	HTTP_STATUS_PROXY_AUTH_REQUIRED	= 407,
-	HTTP_STATUS_REQUEST_TIMEOUT		= 408,
-	HTTP_STATUS_CONFLICT			= 409,
-	HTTP_STATUS_GONE				= 410,
-	HTTP_STATUS_LENGTH_REQUIRED		= 411,
-	HTTP_STATUS_PRECONDITION_FAILED	= 412,
-	HTTP_STATUS_REQ_ENT_TOO_LARGE	= 413,
-	HTTP_STATUS_REQ_URI_TOO_LONG	= 414,
-	HTTP_STATUS_UNSUPP_MEDIA_TYPE	= 415,
-	HTTP_STATUS_REQ_RANGE_NOT_SATIS	= 416,
-	HTTP_STATUS_EXPECTATION_FAILED	= 417,
-
-	HTTP_STATUS_INTERNAL_SERVER_ERR	= 500,
-	HTTP_STATUS_NOT_IMPLEMENTED		= 501,
-	HTTP_STATUS_BAD_GATEWAY			= 502,
-	HTTP_STATUS_SERVICE_UNAVAILABLE	= 503,
-	HTTP_STATUS_GATEWAY_TIMEOUT		= 504,
-	HTTP_STATUS_HTTP_VER_NOT_SUPP	= 505,
-};
-
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// general purpose linked list. Actually isn't very portable
-// because uses only 'name' and 'value' variables to store data.
-// Probably, in a future release, this will be replaced by
-// another type of struct
-typedef struct formvarsA {
-        char *name;
-        char *value;
-        struct formvarsA *next;
-} formvars;
 
 extern formvars *formvars_start;
 extern formvars *formvars_last;

--- a/include/libcgi/cgi_types.h
+++ b/include/libcgi/cgi_types.h
@@ -1,0 +1,90 @@
+/*******************************************************************//**
+ *	@file		libcgi/cgi_types.h
+ *
+ *	@brief		Type definitions for libcgi.
+ *
+ *	@author		Alexander Dahl <post@lespocky.de>
+ *
+ *	SPDX-License-Identifier: LGPL-2.1+
+ *	License-Filename: LICENSES/LGPL-2.1.txt
+ *
+ *	@copyright	2018 Alexander Dahl <post@lespocky.de>
+ **********************************************************************/
+
+#ifndef CGI_TYPES_H
+#define CGI_TYPES_H
+
+/**
+ *	HTTP status codes.
+ *
+ *	@see	http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+ */
+enum cgi_http_status_code {
+	HTTP_STATUS_CONTINUE			= 100,
+	HTTP_STATUS_SWITCHING_PROTOCOLS	= 101,
+
+	HTTP_STATUS_OK					= 200,
+	HTTP_STATUS_CREATED				= 201,
+	HTTP_STATUS_ACCEPTED			= 202,
+	HTTP_STATUS_NON_AUTH_INFO		= 203,
+	HTTP_STATUS_NO_CONTENT			= 204,
+	HTTP_STATUS_RESET_CONTENT		= 205,
+	HTTP_STATUS_PARTIAL_CONTENT		= 206,
+
+	HTTP_STATUS_MULTIPLE_CHOICES	= 300,
+	HTTP_STATUS_MOVED_PERMANENTLY	= 301,
+	HTTP_STATUS_FOUND				= 302,
+	HTTP_STATUS_SEE_OTHER			= 303,
+	HTTP_STATUS_NOT_MODIFIED		= 304,
+	HTTP_STATUS_USE_PROXY			= 305,
+	HTTP_STATUS_TEMPORARY_REDIRECT	= 307,
+
+	HTTP_STATUS_BAD_REQUEST			= 400,
+	HTTP_STATUS_UNAUTHORIZED		= 401,
+	HTTP_STATUS_PAYMENT_REQUIRED	= 402,
+	HTTP_STATUS_FORBIDDEN			= 403,
+	HTTP_STATUS_NOT_FOUND			= 404,
+	HTTP_STATUS_METHOD_NOT_ALLOWED	= 405,
+	HTTP_STATUS_NOT_ACCEPTABLE		= 406,
+	HTTP_STATUS_PROXY_AUTH_REQUIRED	= 407,
+	HTTP_STATUS_REQUEST_TIMEOUT		= 408,
+	HTTP_STATUS_CONFLICT			= 409,
+	HTTP_STATUS_GONE				= 410,
+	HTTP_STATUS_LENGTH_REQUIRED		= 411,
+	HTTP_STATUS_PRECONDITION_FAILED	= 412,
+	HTTP_STATUS_REQ_ENT_TOO_LARGE	= 413,
+	HTTP_STATUS_REQ_URI_TOO_LONG	= 414,
+	HTTP_STATUS_UNSUPP_MEDIA_TYPE	= 415,
+	HTTP_STATUS_REQ_RANGE_NOT_SATIS	= 416,
+	HTTP_STATUS_EXPECTATION_FAILED	= 417,
+
+	HTTP_STATUS_INTERNAL_SERVER_ERR	= 500,
+	HTTP_STATUS_NOT_IMPLEMENTED		= 501,
+	HTTP_STATUS_BAD_GATEWAY			= 502,
+	HTTP_STATUS_SERVICE_UNAVAILABLE	= 503,
+	HTTP_STATUS_GATEWAY_TIMEOUT		= 504,
+	HTTP_STATUS_HTTP_VER_NOT_SUPP	= 505,
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ *	General purpose linked list. Actually isn't very portable because
+ *	uses only 'name' and 'value' variables to store data. Probably, in
+ *	a future release, this will be replaced by another type of struct.
+ */
+typedef struct formvarsA {
+	char *name;
+	char *value;
+	struct formvarsA *next;
+} formvars;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CGI_TYPES_H */
+
+/* vim: set noet sts=0 ts=4 sw=4 sr: */

--- a/src/cgi.c
+++ b/src/cgi.c
@@ -9,7 +9,6 @@
 
 #include "libcgi/cgi.h"
 
-
 #include <ctype.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -17,6 +16,7 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#include "libcgi/cgi_types.h"
 #include "libcgi/config.h"
 #include "libcgi/error.h"
 

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -13,6 +13,7 @@
 #include <string.h>
 
 #include "libcgi/cgi.h"
+#include "libcgi/cgi_types.h"
 #include "libcgi/error.h"
 
 formvars *cookies_start = NULL;

--- a/src/list.c
+++ b/src/list.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "libcgi/cgi.h"
+#include "libcgi/cgi_types.h"
 
 // Add a new item to the list
 void slist_add(formvars *item, formvars **start, formvars **last)

--- a/src/session.c
+++ b/src/session.c
@@ -57,6 +57,7 @@
 #include <unistd.h>
 
 #include "libcgi/cgi.h"
+#include "libcgi/cgi_types.h"
 #include "libcgi/error.h"
 
 // session id length

--- a/test/test.c
+++ b/test/test.c
@@ -16,6 +16,7 @@
 #include "cgi_test.h"
 
 #include "libcgi/cgi.h"
+#include "libcgi/cgi_types.h"
 #include "libcgi/config.h"
 
 extern formvars *

--- a/test/test_slist.c
+++ b/test/test_slist.c
@@ -18,6 +18,7 @@
 #include "cgi_test.h"
 
 #include "libcgi/cgi.h"
+#include "libcgi/cgi_types.h"
 
 /*	declarations for functions not declared in src	*/
 formvars *process_data(const char *query, formvars **start, formvars **last,


### PR DESCRIPTION
This way consumers can include the new `cgi_types.h` only, and do not need
to include the whole `cgi.h`.

Bump version, so you can depend on that new header file.